### PR TITLE
Add dependencies and git submodules to BUILDING

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -1,1 +1,13 @@
-To build Ion, use the build.sh or build.py scripts in the ion/ directory.
+1. Install dependencies
+  - gyp
+  - clang
+  - libc++-dev
+  - libc++abi-dev
+
+2. Update git submodules
+  ```
+  git submodule init
+  git submodule update
+  ```
+
+3. Build by running `build.sh` or `build.py` in the `ion/` directory.


### PR DESCRIPTION
Still running into the following:

/usr/bin/../lib/gcc/x86_64-linux-gnu/5.2.1/../../../../include/c++/5.2.1/bits/atomic_base.h:354: undefined reference to `__atomic_is_lock_free'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
[4/334] CXX obj/ion/base/tests/ionbase_test.datetime_test.o
ninja: build stopped: subcommand failed.
