### PR TITLE
Use references when joining threads in KillAllThreads

### DIFF
--- a/ion/base/workerpool.cc
+++ b/ion/base/workerpool.cc
@@ -126,7 +126,7 @@ void WorkerPool::KillAllThreads() {
   }
 
   // Wait for all threads to finish.
-  for (auto thread_id : threads_) {
+  for (const auto& thread_id : threads_) {
     bool join_succeeded = port::JoinThread(thread_id);
     DCHECK(join_succeeded);
   }


### PR DESCRIPTION
Super super small change. It might be nice to use `const` references when iterating through `threads_` and joining by `thread_id` in [`WorkerPool::KillAllThreads`](https://github.com/danlrobertson/ion/blob/master/ion/base/workerpool.cc#L115).  `thread_id` will be copied by [`port::JoinThread`](https://github.com/danlrobertson/ion/blob/master/ion/port/threadutils.cc#L224).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/ion/7)

<!-- Reviewable:end -->
