### PR TITLE
Update common.gypi

### DIFF
--- a/ion/common.gypi
+++ b/ion/common.gypi
@@ -334,6 +334,7 @@
             '-lc_nonshared',
             '-ldl',
             '-lgcc',
+            '-latomic',
           ],
         },
         'cflags': [


### PR DESCRIPTION
added -latomic to avoid linker error in linux
